### PR TITLE
cache go mod files when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download -x
+RUN --mount=type=cache,target=/go/pkg/mod go mod download -x
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   BIN_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build
 
 FROM alpine


### PR DESCRIPTION
Current code uses go build cache and saves a lot of time, but it still downloads all dependencies when even a single line of go.mod or go.sum changes, which is a big waste of CPU cycles and network traffic. This PR caches go modules too.