### PR TITLE
Tweaks for the simpler auctioneer winner selection flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/textileio/go-datastore-extensions v1.0.1
 	github.com/textileio/go-ds-badger3 v0.0.0-20210324034212-7b7fb3be3d1c
 	github.com/textileio/go-ds-mongo v0.1.4
-	github.com/textileio/go-libp2p-pubsub-rpc v0.0.1
+	github.com/textileio/go-libp2p-pubsub-rpc v0.0.2
 	github.com/textileio/go-log/v2 v2.1.3-gke-1
 	github.com/urfave/cli/v2 v2.3.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -1700,8 +1700,8 @@ github.com/textileio/go-ds-badger3 v0.0.0-20210324034212-7b7fb3be3d1c h1:iOWa9/A
 github.com/textileio/go-ds-badger3 v0.0.0-20210324034212-7b7fb3be3d1c/go.mod h1:VX3oCNk7szANGG+baANuhTx7dheWiEPH7lp1n69ef4M=
 github.com/textileio/go-ds-mongo v0.1.4 h1:5PPMEmqCfeCySzadtuBXMEJVDGP1Cga/CQXo3GWetmE=
 github.com/textileio/go-ds-mongo v0.1.4/go.mod h1:Zf6JlMPiIQUUmGlFFn5Z65C9p9LAvPg7XvX+qdGmTsU=
-github.com/textileio/go-libp2p-pubsub-rpc v0.0.1 h1:h1dTR2eKKBZuCuVuNqRi/Mg8Rye1GSCxpK7vU+H0i00=
-github.com/textileio/go-libp2p-pubsub-rpc v0.0.1/go.mod h1:hZ9OeFmGIjjH1fqahmxj6yvlPR6X7uPZ2rII1SyTsog=
+github.com/textileio/go-libp2p-pubsub-rpc v0.0.2 h1:+LjGp5ByapB4XqU9WHhVodXlaHwT7baOMrRXwIoK5O4=
+github.com/textileio/go-libp2p-pubsub-rpc v0.0.2/go.mod h1:hZ9OeFmGIjjH1fqahmxj6yvlPR6X7uPZ2rII1SyTsog=
 github.com/textileio/go-log/v2 v2.1.3-gke-1 h1:7e3xSUXQB8hn4uUe5fp41kLThW1o9T65gSM7qjS323g=
 github.com/textileio/go-log/v2 v2.1.3-gke-1/go.mod h1:DwACkjFS3kjZZR/4Spx3aPfSsciyslwUe5bxV8CEU2w=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=

--- a/lib/auction/auction.go
+++ b/lib/auction/auction.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/ipfs/go-cid"
-	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
 )
 
@@ -26,25 +24,6 @@ const (
 
 // BidID is a unique identifier for a Bid.
 type BidID string
-
-// Bid defines the core bid model.
-type Bid struct {
-	MinerAddr        string
-	WalletAddrSig    []byte
-	BidderID         peer.ID
-	AskPrice         int64 // attoFIL per GiB per epoch
-	VerifiedAskPrice int64 // attoFIL per GiB per epoch
-	StartEpoch       uint64
-	FastRetrieval    bool
-	ReceivedAt       time.Time
-}
-
-// WinningBid contains details about a winning bid.
-type WinningBid struct {
-	BidderID    peer.ID
-	ProposalCid cid.Cid
-	ErrorCause  string // an error that may have occurred when delivering the proposal cid
-}
 
 // CARURL contains details of a CAR file stored in an HTTP endpoint.
 type CARURL struct {

--- a/lib/auction/auction.go
+++ b/lib/auction/auction.go
@@ -41,10 +41,9 @@ type Bid struct {
 
 // WinningBid contains details about a winning bid.
 type WinningBid struct {
-	BidderID                peer.ID
-	Acknowledged            bool // Whether or not the bidder acknowledged receipt of the win
-	ProposalCid             cid.Cid
-	ProposalCidAcknowledged bool // Whether or not the bidder acknowledged receipt of the proposal Cid
+	BidderID    peer.ID
+	ProposalCid cid.Cid
+	ErrorCause  string // an error that may have occurred when delivering the proposal cid
 }
 
 // CARURL contains details of a CAR file stored in an HTTP endpoint.
@@ -92,10 +91,10 @@ func (s Sources) String() string {
 	var b strings.Builder
 	_, _ = b.WriteString("{")
 	if s.CARURL != nil {
-		fmt.Fprintf(&b, "url: %s,", s.CARURL.URL.String())
+		_, _ = fmt.Fprintf(&b, "url: %s,", s.CARURL.URL.String())
 	}
 	if s.CARIPFS != nil {
-		fmt.Fprintf(&b, "cid: %s,", s.CARIPFS.Cid.String())
+		_, _ = fmt.Fprintf(&b, "cid: %s,", s.CARIPFS.Cid.String())
 	}
 	_, _ = b.WriteString("}")
 	return b.String()

--- a/lib/auction/topics.go
+++ b/lib/auction/topics.go
@@ -6,26 +6,26 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
-// AuctionID is a unique identifier for an Auction.
-type AuctionID string
+// ID is a unique identifier for an Auction.
+type ID string
 
-// AuctionTopic is used by brokers to publish and by miners to subscribe to deal auction.
-const AuctionTopic string = "/textile/auction/0.0.1"
+// Topic is used by brokers to publish and by miners to subscribe to deal auction.
+const Topic string = "/textile/auction/0.0.1"
 
 // BidsTopic is used by miners to submit deal auction bids.
 // "/textile/auction/0.0.1/<auction_id>/bids".
-func BidsTopic(auctionID AuctionID) string {
-	return path.Join(AuctionTopic, string(auctionID), "bids")
+func BidsTopic(auctionID ID) string {
+	return path.Join(Topic, string(auctionID), "bids")
 }
 
 // WinsTopic is used by brokers to notify a bidbot that it has won the deal auction.
 // "/textile/auction/0.0.1/<peer_id>/wins".
 func WinsTopic(pid peer.ID) string {
-	return path.Join(AuctionTopic, pid.String(), "wins")
+	return path.Join(Topic, pid.String(), "wins")
 }
 
 // ProposalsTopic is used by brokers to notify a bidbot of the proposal cid.Cid for an accepted deal auction.
 // "/textile/auction/0.0.1/<peer_id>/proposals".
 func ProposalsTopic(pid peer.ID) string {
-	return path.Join(AuctionTopic, pid.String(), "proposals")
+	return path.Join(Topic, pid.String(), "proposals")
 }

--- a/service/service.go
+++ b/service/service.go
@@ -239,7 +239,7 @@ func (s *Service) Subscribe(bootstrap bool) error {
 	}
 
 	// Subscribe to the global auctions topic
-	auctions, err := s.peer.NewTopic(s.ctx, auction.AuctionTopic, true)
+	auctions, err := s.peer.NewTopic(s.ctx, auction.Topic, true)
 	if err != nil {
 		return fmt.Errorf("creating auction topic: %v", err)
 	}
@@ -416,7 +416,7 @@ func (s *Service) makeBid(a *pb.Auction, from core.ID) error {
 	}
 
 	// Create bids topic
-	topic, err := s.peer.NewTopic(s.ctx, auction.BidsTopic(auction.AuctionID(a.Id)), false)
+	topic, err := s.peer.NewTopic(s.ctx, auction.BidsTopic(auction.ID(a.Id)), false)
 	if err != nil {
 		return fmt.Errorf("creating bids topic: %v", err)
 	}
@@ -467,7 +467,7 @@ func (s *Service) makeBid(a *pb.Auction, from core.ID) error {
 	// Save bid locally
 	if err := s.store.SaveBid(bidstore.Bid{
 		ID:               auction.BidID(id),
-		AuctionID:        auction.AuctionID(a.Id),
+		AuctionID:        auction.ID(a.Id),
 		AuctioneerID:     from,
 		PayloadCid:       payloadCid,
 		DealSize:         a.DealSize,

--- a/service/service.go
+++ b/service/service.go
@@ -34,7 +34,7 @@ var (
 	log = golog.Logger("bidbot/service")
 
 	// bidsAckTimeout is the max duration bidbot will wait for an ack after bidding in an auction.
-	bidsAckTimeout = time.Second * 10
+	bidsAckTimeout = time.Second * 30
 
 	// dataURIValidateTimeout is the timeout used when validating a data uri.
 	dataURIValidateTimeout = time.Minute

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -70,7 +70,7 @@ var (
 // Bid defines the core bid model from a miner's perspective.
 type Bid struct {
 	ID                   auction.BidID
-	AuctionID            auction.AuctionID
+	AuctionID            auction.ID
 	AuctioneerID         peer.ID
 	PayloadCid           cid.Cid
 	DealSize             uint64

--- a/service/store/store_test.go
+++ b/service/store/store_test.go
@@ -55,7 +55,7 @@ func TestStore_ListBids(t *testing.T) {
 	for i := 0; i < limit; i++ {
 		now = now.Add(time.Millisecond)
 		id := auction.BidID(strings.ToLower(ulid.MustNew(ulid.Timestamp(now), rand.Reader).String()))
-		aid := auction.AuctionID(strings.ToLower(ulid.MustNew(ulid.Now(), rand.Reader).String()))
+		aid := auction.ID(strings.ToLower(ulid.MustNew(ulid.Now(), rand.Reader).String()))
 		_, sources, err := gw.CreateHTTPSources(true)
 		require.NoError(t, err)
 
@@ -294,7 +294,7 @@ func newBid(t *testing.T, dag format.DAGService, carAccessible bool) *Bid {
 
 	now := time.Now()
 	id := auction.BidID(strings.ToLower(ulid.MustNew(ulid.Timestamp(now), rand.Reader).String()))
-	aid := auction.AuctionID(strings.ToLower(ulid.MustNew(ulid.Now(), rand.Reader).String()))
+	aid := auction.ID(strings.ToLower(ulid.MustNew(ulid.Now(), rand.Reader).String()))
 	return &Bid{
 		ID:               id,
 		AuctionID:        aid,


### PR DESCRIPTION
- Updates https://github.com/textileio/go-libp2p-pubsub-rpc with the new republish feature.
- Modifies the `WinningBid` model (see below).