### PR TITLE
common: properly handle SIGTERM for k8

### DIFF
--- a/lib/common/daemon.go
+++ b/lib/common/daemon.go
@@ -203,7 +203,7 @@ func CheckErrf(format string, err error) {
 // HandleInterrupt attempts to cleanup while allowing the user to force stop the process.
 func HandleInterrupt(cleanup func()) {
 	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 	<-quit
 	fmt.Println("Gracefully stopping... (press Ctrl+C again to force)")
 	cleanup()

--- a/lib/common/daemon.go
+++ b/lib/common/daemon.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gogo/status"
@@ -202,7 +203,7 @@ func CheckErrf(format string, err error) {
 // HandleInterrupt attempts to cleanup while allowing the user to force stop the process.
 func HandleInterrupt(cleanup func()) {
 	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, os.Interrupt)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
 	<-quit
 	fmt.Println("Gracefully stopping... (press Ctrl+C again to force)")
 	cleanup()


### PR DESCRIPTION
This was only considering SIGINT, and not SIGTERM which is sent by k8 for graceful termination.
Since we use this `common` package for all SB daemons, means that all of them weren't closing gracefully.

I'll update the dependency on all places in the other repo when merged.