### PR TITLE
add version command; also print config file when start daemon

### DIFF
--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/textileio/bidbot/buildinfo"
 	"github.com/textileio/bidbot/lib/auction"
 	"github.com/textileio/bidbot/lib/datauri"
 	bidstore "github.com/textileio/bidbot/service/store"
@@ -48,6 +49,7 @@ func createMux(service Service) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", getOnly(healthHandler))
 	mux.HandleFunc("/id", getOnly(idHandler(service)))
+	mux.HandleFunc("/version", getOnly(versionHandler))
 	// allow both with and without trailing slash
 	deals := getOnly(dealsHandler(service))
 	mux.HandleFunc("/deals", deals)
@@ -89,6 +91,10 @@ func idHandler(service Service) http.HandlerFunc {
 			log.Errorf("write failed: %v", err)
 		}
 	}
+}
+
+func versionHandler(w http.ResponseWriter, _ *http.Request) {
+	_, _ := w.Write([]byte(buildinfo.Summary()))
 }
 
 func dealsHandler(service Service) http.HandlerFunc {

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -94,7 +94,7 @@ func idHandler(service Service) http.HandlerFunc {
 }
 
 func versionHandler(w http.ResponseWriter, _ *http.Request) {
-	_, _ := w.Write([]byte(buildinfo.Summary()))
+	_, _ = w.Write([]byte(buildinfo.Summary()))
 }
 
 func dealsHandler(service Service) http.HandlerFunc {

--- a/lib/peerflags/peerflags.go
+++ b/lib/peerflags/peerflags.go
@@ -180,8 +180,3 @@ func WriteConfig(v *viper.Viper, repoPathEnv, defaultRepoPath string) (string, e
 	}
 	return cf, nil
 }
-
-// MarshalConfig marshals a *viper.Viper config to JSON.
-func MarshalConfig(v *viper.Viper, pretty bool) ([]byte, error) {
-	return common.MarshalConfig(v, pretty, "private-key", "wallet-addr-sig")
-}

--- a/main.go
+++ b/main.go
@@ -411,6 +411,7 @@ var versionCmd = &cobra.Command{
 			fmt.Println(local)
 			return
 		}
+		fmt.Println("WARNING! You local and remote version don't match:")
 		fmt.Printf("local%s\n", local)
 		fmt.Printf("\ndaemon%s\n", remote)
 	},


### PR DESCRIPTION
Validating version is something I kept wanting to when chatting with miners, and even when trying myself.

Printing config file on startup can also avoid some confusions by miners.