### PR TITLE
add est-download-speed to make data fetching timeout adjustable

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,6 +125,12 @@ func init() {
 			Description: "The timeout before discarding deal with no progress",
 		},
 		{
+			Name:     "est-download-speed",
+			DefValue: "5MB",
+			Description: `The estimated download speed per second, to govern the timeouts downloading CAR files.
+Be conservative to leave enough room for network instability.`,
+		},
+		{
 			Name:     "running-bytes-limit",
 			DefValue: "",
 			Description: `Maximum running total bytes in the deals to bid for a period of time.
@@ -310,8 +316,10 @@ var daemonCmd = &cobra.Command{
 			dealDataDirectory = filepath.Join(defaultConfigPath, "deal_data")
 		}
 
-		var bytesLimiter limiter.Limiter = limiter.NopeLimiter{}
+		estDownloadSpeed, err := humanize.ParseBytes(v.GetString("est-download-speed"))
+		common.CheckErrf("parsing est-download-speed: %v", err)
 
+		var bytesLimiter limiter.Limiter = limiter.NopeLimiter{}
 		if limit := v.GetString("running-bytes-limit"); limit != "" {
 			lim, err := parseRunningBytesLimit(limit)
 			common.CheckErrf(fmt.Sprintf("parsing '%s': %%w", limit), err)
@@ -342,6 +350,7 @@ var daemonCmd = &cobra.Command{
 				},
 			},
 			BytesLimiter:        bytesLimiter,
+			EstDownloadSpeed:    estDownloadSpeed,
 			SealingSectorsLimit: v.GetInt("sealing-sectors-limit"),
 		}
 		serv, err := service.New(config, store, lc, fc)

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func init() {
 		},
 		{
 			Name:     "est-download-speed",
-			DefValue: "5MB",
+			DefValue: "1MB",
 			Description: `The estimated download speed per second, to govern the timeouts downloading CAR files.
 Be conservative to leave enough room for network instability.`,
 		},

--- a/service/service.go
+++ b/service/service.go
@@ -46,6 +46,7 @@ type Config struct {
 	BidParams           BidParams
 	AuctionFilters      AuctionFilters
 	BytesLimiter        limiter.Limiter
+	EstDownloadSpeed    uint64
 	SealingSectorsLimit int
 }
 
@@ -182,6 +183,7 @@ func New(
 		conf.BidParams.DealDataFetchAttempts,
 		conf.BidParams.DiscardOrphanDealsAfter,
 		conf.BytesLimiter,
+		conf.EstDownloadSpeed,
 	)
 	if err != nil {
 		return nil, fin.Cleanupf("creating bid store: %v", err)
@@ -297,7 +299,7 @@ func (s *Service) GetBid(id auction.BidID) (*bidstore.Bid, error) {
 
 // WriteDataURI writes a data uri resource to the configured deal data directory.
 func (s *Service) WriteDataURI(payloadCid, uri string) (string, error) {
-	return s.store.WriteDataURI("", payloadCid, uri)
+	return s.store.WriteDataURI("", payloadCid, uri, 0)
 }
 
 func (s *Service) eventHandler(from core.ID, topic string, msg []byte) {

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -49,7 +49,7 @@ var (
 	DefaultDataURIFetchTimeout = time.Hour * 10
 
 	// MaxDataURIFetchConcurrency is the maximum number of data uri fetches that will be handled concurrently.
-	MaxDataURIFetchConcurrency = 10
+	MaxDataURIFetchConcurrency = 3
 
 	// ErrBidNotFound indicates the requested bid was not found.
 	ErrBidNotFound = errors.New("bid not found")

--- a/service/store/store_test.go
+++ b/service/store/store_test.go
@@ -34,8 +34,6 @@ func init() {
 	}); err != nil {
 		panic(err)
 	}
-
-	DataURIFetchTimeout = time.Second * 5
 }
 
 func TestStore_ListBids(t *testing.T) {
@@ -260,7 +258,7 @@ func newStore(t *testing.T) (*Store, format.DAGService, blockstore.Blockstore) {
 		PrivKey:  sk,
 	})
 	require.NoError(t, err)
-	s, err := NewStore(ds, p.Host(), p.DAGService(), newLotusClientMock(), t.TempDir(), 2, 0, limiter.NopeLimiter{})
+	s, err := NewStore(ds, p.Host(), p.DAGService(), newLotusClientMock(), t.TempDir(), 2, 0, limiter.NopeLimiter{}, 1<<30)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, s.Close())


### PR DESCRIPTION
Adding this seemingly useful feature, while I'm here.

Resolves https://github.com/textileio/bidbot/issues/33