### PR TITLE
add flag to limit the number of concurrent importing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	go.opentelemetry.io/otel/sdk/export/metric v0.21.0
 	go.opentelemetry.io/otel/sdk/metric v0.21.0
 	go.uber.org/zap v1.18.1
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.39.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/main.go
+++ b/main.go
@@ -142,6 +142,12 @@ Also take the file system overhead into consideration when calculating the limit
 No limit by default.`,
 		},
 		{
+			Name:        "concurrent-imports-limit",
+			DefValue:    0,
+			Description: `If bigger than zero, only run that many imports concurrently. Zero means no limits.`,
+		},
+
+		{
 			Name:     "sealing-sectors-limit",
 			DefValue: 0,
 			Description: `If bigger than zero, stop bidding if the number of Lotus sealing sectors exceeds this limit.
@@ -352,6 +358,7 @@ var daemonCmd = &cobra.Command{
 				},
 			},
 			BytesLimiter:        bytesLimiter,
+			ConcurrentImports:   v.GetInt("concurrent-imports-limit"),
 			EstDownloadSpeed:    estDownloadSpeed,
 			SealingSectorsLimit: v.GetInt("sealing-sectors-limit"),
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -46,6 +46,7 @@ type Config struct {
 	BidParams           BidParams
 	AuctionFilters      AuctionFilters
 	BytesLimiter        limiter.Limiter
+	ConcurrentImports   int
 	EstDownloadSpeed    uint64
 	SealingSectorsLimit int
 }
@@ -183,6 +184,7 @@ func New(
 		conf.BidParams.DealDataFetchAttempts,
 		conf.BidParams.DiscardOrphanDealsAfter,
 		conf.BytesLimiter,
+		conf.ConcurrentImports,
 		conf.EstDownloadSpeed,
 	)
 	if err != nil {

--- a/service/store/store_test.go
+++ b/service/store/store_test.go
@@ -258,7 +258,8 @@ func newStore(t *testing.T) (*Store, format.DAGService, blockstore.Blockstore) {
 		PrivKey:  sk,
 	})
 	require.NoError(t, err)
-	s, err := NewStore(ds, p.Host(), p.DAGService(), newLotusClientMock(), t.TempDir(), 2, 0, limiter.NopeLimiter{}, 1<<30)
+	s, err := NewStore(ds, p.Host(), p.DAGService(), newLotusClientMock(),
+		t.TempDir(), 2, 0, limiter.NopeLimiter{}, 1, 1<<30)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, s.Close())


### PR DESCRIPTION
miners have seen market node OOM importing data concurrently (unrelated to bidbot), figure this can help. per stuberman importing 32GB usually takes 10 minutes without concurrency, but can be much longer if there are 2 imports at the same time.

we could recommend miners to use `--running-bytes-limit`, but it has a tricky bug.