### PR TITLE
ditch est-download-speed, add deal-data-fetch-timeout

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -47,7 +47,6 @@ type Config struct {
 	AuctionFilters      AuctionFilters
 	BytesLimiter        limiter.Limiter
 	ConcurrentImports   int
-	EstDownloadSpeed    uint64
 	SealingSectorsLimit int
 }
 
@@ -71,6 +70,8 @@ type BidParams struct {
 	DealDataDirectory string
 	// DealDataFetchAttempts is the number of times fetching deal data cid will be attempted.
 	DealDataFetchAttempts uint32
+	// DealDataFetchTimeout is the timeout fetching deal data cid.
+	DealDataFetchTimeout time.Duration
 	// DiscardOrphanDealsAfter is the time after which deals with no progress will be removed.
 	DiscardOrphanDealsAfter time.Duration
 }
@@ -182,10 +183,10 @@ func New(
 		lc,
 		conf.BidParams.DealDataDirectory,
 		conf.BidParams.DealDataFetchAttempts,
+		conf.BidParams.DealDataFetchTimeout,
 		conf.BidParams.DiscardOrphanDealsAfter,
 		conf.BytesLimiter,
 		conf.ConcurrentImports,
-		conf.EstDownloadSpeed,
 	)
 	if err != nil {
 		return nil, fin.Cleanupf("creating bid store: %v", err)

--- a/service/store/store_test.go
+++ b/service/store/store_test.go
@@ -259,7 +259,7 @@ func newStore(t *testing.T) (*Store, format.DAGService, blockstore.Blockstore) {
 	})
 	require.NoError(t, err)
 	s, err := NewStore(ds, p.Host(), p.DAGService(), newLotusClientMock(),
-		t.TempDir(), 2, 0, limiter.NopeLimiter{}, 1, 1<<30)
+		t.TempDir(), 2, time.Second, 0, limiter.NopeLimiter{}, 1<<30)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, s.Close())


### PR DESCRIPTION
`est-download-speed` was added by https://github.com/textileio/bidbot/pull/35, but created some confusing on what's the optimal value to be set, and what it's used for. I was too clever when adding that. So here we just remove that flag and replace with `deal-data-fetch-timeout`, which is more straightforward, and is exactly what asked for https://github.com/textileio/bidbot/issues/33
