### PR TITLE
check for running-bytes-limit only after winning an auction

### DIFF
--- a/lib/auction/auction.go
+++ b/lib/auction/auction.go
@@ -20,6 +20,11 @@ const (
 	// HTTPCarHeaderOnly is a HTTP header indicating that the bidbot wants
 	// only the CAR file header, as a hint to the HTTP server.
 	HTTPCarHeaderOnly = "X-Bidbot-Car-Header-Only"
+
+	// ErrStringWouldExceedRunningBytesLimit is the error message bidbot responds to wins
+	// message if proceeding with the bid would exceed the running bytes
+	// limit.
+	ErrStringWouldExceedRunningBytesLimit = "would exceed running bytes limit"
 )
 
 // BidID is a unique identifier for a Bid.

--- a/service/service.go
+++ b/service/service.go
@@ -43,6 +43,8 @@ var (
 
 	// dataURIValidateTimeout is the timeout used when validating a data uri.
 	dataURIValidateTimeout = time.Minute
+
+	errWouldExceedRunningBytesLimit = errors.New(auction.ErrStringWouldExceedRunningBytesLimit)
 )
 
 // Config defines params for Service configuration.
@@ -492,7 +494,7 @@ func (s *Service) winsHandler(from core.ID, topic string, msg []byte) ([]byte, e
 		// the auction.
 		granted := s.bytesLimiter.Request(win.AuctionId, bid.DealSize, BidsExpiration)
 		if !granted {
-			return nil, errors.New("actively reject to avoid hitting running bytes limit")
+			return nil, errWouldExceedRunningBytesLimit
 		}
 	}
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -198,6 +198,8 @@ func TestBytesLimit(t *testing.T) {
 		if !expectGoodResponse {
 			require.Error(t, winsResponseError,
 				fmt.Sprintf("should have responded error for wins in auction %s", auctionID))
+			require.Equal(t, core.ErrStringWouldExceedRunningBytesLimit, winsResponseError.Error(),
+				fmt.Sprintf("should have responded expected error message in auction %s", auctionID))
 		} else {
 			require.NoError(t, winsResponseError,
 				fmt.Sprintf("should have had not error for wins in auction %s", auctionID))


### PR DESCRIPTION
and responds error deliberately if the limit is hit.

This is yet another temporary fix. When participating in an auction, bidbot won't know if it will win or not, so it has to request for running bytes quota. But there is no way to know if it loses an auction to return the quota, so it has to wait for certain time (hardcoded 10 minutes for now) at which period it may miss many auctions.

With this change, the limit is checked only after winning an auction, with the downside that auctioneer would say many errors, which is undesired.

Two options I can think of:
1. Add a protobuf field for active rejection;
2. have auctioneer broadcasting the winners so bidbot can reset the quota ASAP.