### PR TITLE
specify Go version when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
             type=semver,pattern={{version}}
             type=sha,prefix=sha-
 
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+
       - name: Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
The default is 1.15.15, which doesn't have some library Filecoin requires. It's also good to make the Go version more apparent, though it would be even better if we can specify version across all actions (which I don't know a way exists).