### PR TITLE
lotusclient: wire NetStruct

### DIFF
--- a/service/lotusclient/lotusclient.go
+++ b/service/lotusclient/lotusclient.go
@@ -163,6 +163,7 @@ func newBuilder(maddrs string, authToken string, connRetries int) (clientBuilder
 			closer, err = jsonrpc.NewMergeClient(context.Background(), "ws://"+addr+"/rpc/v0", "Filecoin",
 				[]interface{}{
 					&api.CommonStruct.Internal,
+					&api.NetStruct.Internal,
 					&api.Internal,
 				}, headers)
 			if err == nil {


### PR DESCRIPTION
Wire `NetStruct` in the API.
This was the root cause of https://github.com/textileio/bidbot/pull/48 break.