### PR TITLE
doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The Auctioneer collects all bids from connected storage providers and chooses on
 
 If you win an auction, you will be notified about it! If that weren't the case, most probably you'll have better luck in the next auction!
 
-The Auctioneer relies on offline deals to make deals with storage providers. After you win an auction, you will pull the deal data from the place given to your bidbot. You can think of this flow as an *automatic* offline deal setup where instead of receiving hard drives, you'll pull the data from someplace and then receive the offline-deal proposal.
+The Auctioneer relies on offline deals to make deals with storage providers. After you win an auction, your bidbot will pull the deal data from the client. You can think of this flow as an *automatic* offline deal setup where instead of receiving hard drives, you'll pull the data from someplace and then receive the offline-deal proposal.
 
 # How do I connect with the system?
 
@@ -79,7 +79,7 @@ To connect to the system, you will install `bidbot`, a daemon that you run on yo
 
 The `bidbot` talks to the Auctioneer through libp2p pubsub topics. This is the same technology used by many `libp2p` applications such as `lotus`. Through these topics, your `bidbot` daemon will receive new *auctions* and can send *bids* to participate.
 
-Whenever you win an auction, your `lotus-miner` will receive the deal proposal for the corresponding data so you can accept it, and a *ProposalCid* is generated. After acceptance, your `bidbot` will automatically download the *PayloadCid* data from the URL or IPFS multiaddrs given, and import it as you generally do with offline deals, simulating the following commands you might be aware of: `lotus-miner storage-deals import-data <dealCid> <carFilePath>`
+Whenever you win an auction, your `lotus-miner` will receive the deal proposal for the corresponding data so you can accept it, and a *ProposalCid* is generated. After acceptance, your `bidbot` will automatically download the *PayloadCid* data via the URL or IPFS multiaddrs given by the client, and import it as you generally do with offline deals, simulating the following commands you might be aware of: `lotus-miner storage-deals import-data <dealCid> <carFilePath>`
 
 The `carFilePath` is the CAR file that `bidbot` generated after downloading the deals data. The *dealCid* is the *ProposalCid* of the proposal you previously accepted from the Auctioneer.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Join us on our [public Slack channel](https://slack.textile.io/) for news, discu
 ## Table of Contents
 
 - [Installation](#installation)
-- [What is the Storage Broker](#what-is-the-storage-broker)
+- [What is the Auctioneer](#what-is-an-auctioneer)
 - [How do I connect with the system?](#how-do-i-connect-with-the-system)
 - [Useful `bidbot` commands](#useful-bidbot-operational-commands)
 - [Contributing](#contributing)
@@ -28,60 +28,60 @@ cd bidbot
 make install
 ```
 
-# What is the Storage Broker?
+# What is an Auctioneer?
 
-First, we must understand that `bidbot` is a piece that's part of a bigger picture: the storage broker.
-The storage broker (SB) is a system that receives data from multiple clients, aggregates them, and makes it available for storage providers to store. The SB has several unique properties that make it different than your typical Filecoin client. 
+First, we must understand that `bidbot` is a piece that's part of a bigger picture: the storage auction system.
+The storage auction system (Auctioneer) is a system that receives data from multiple clients, aggregates them, and makes it available for storage providers to store. The Auctioneer has several unique properties that make it different than your typical Filecoin client.
 
-1. Miners connect to the SB to discover available data payloads awaiting deals.
-2. Miners bid on deals in real time to offer the best storage solution for each payload.
-3. All deals are offline deals, not online deals. Miners download the data to create the deal.
+1. Storage providers connect to the Auctioneer to discover available data payloads awaiting deals.
+2. Storage providers bid on deals in real time to offer the best storage solution for each payload.
+3. All deals are offline deals, not online deals. Storage providers download the data to create the deal.
 
-Currently the storage-broker is creating a slow stream of auctions, so you might see _nothing happening_ when running `bidbot`. This is expected for some time, so unless you see errors in your logs you can leave the daemon running.
+Currently the Auctioneer is creating a slow stream of auctions, so you might see _nothing happening_ when running `bidbot`. This is expected for some time, so unless you see errors in your logs you can leave the daemon running.
 
 ### How it works
 
-Whenever the SB has aggregates a minimum threshold of data, it attempts to make deals with storage providers. Data payloads awaiting storage is described by the usual attributes you're familiar with in Filecoin:
+Whenever the Auctioneer has aggregates a minimum threshold of data, it attempts to make deals with storage providers. Data payloads awaiting storage is described by the usual attributes you're familiar with in Filecoin:
 
 - PayloadCid (cid)
 - PieceCid (cid)
 - DealSize (int64 in bytes)
 - VerifiedDeal (bool)
 
-To initiate the storage of the new payload, the SB creates an *auction*. The *auction* is published to all connected storage providers to notify them that a new payload is awaiting storage on Filecoin. 
+To initiate the storage of the new payload, the Auctioneer creates an *auction*. The *auction* is published to all connected storage providers to notify them that a new payload is awaiting storage on Filecoin.
 
 To understand better what this is about, consider the following chat:
 
-- [Storage Broker]: "Hey storage providers, there's a new Auction for a dataset with size X, PayloadCid X, PieceCid X, and PieceSize X. This data will be created with a verified deal. Who's interested?"
-- [Miner-A]: "Me! Here's my Bid: price-per-epoch=0.0001FIL and I promise to accept a deal proposal with *DealStartEpoch=XXXX".*
-- [Miner-B]: Hey, me too! My price is 0.00000001FIL, and I promise to accept a deal proposal with DealStartepoch=YYYYY".
-- [Miner-C]: Uhm, I'm too busy now... I won't bid here and just let this pass. Maybe in the next auction!
+- [Auctioneer]: "Hey storage providers, there's a new Auction for a dataset with size X, PayloadCid X, PieceCid X, and PieceSize X. This data will be created with a verified deal. Who's interested?"
+- [Provider-A]: "Me! Here's my Bid: price-per-epoch=0.0001FIL and I promise to accept a deal proposal with *DealStartEpoch=XXXX".*
+- [Provider-B]: Hey, me too! My price is 0.00000001FIL, and I promise to accept a deal proposal with DealStartepoch=YYYYY".
+- [Provider-C]: Uhm, I'm too busy now... I won't bid here and just let this pass. Maybe in the next auction!
 
-Miners will send *bids* to show their interest in participating in the auction. Bids provide the SB multiple pieces of information (i.e. price, start epoch, etc) about the storage provider's storage intent. Unlike the chat based auction, storage providers connected to the SB can configure bidding to happen automatically as fast as the storage provider's infrastructure can handle. 
+Storage providers will send *bids* to show their interest in participating in the auction. Bids provide the Auctioneer multiple pieces of information (i.e. price, start epoch, etc) about the provider's storage intent. Unlike the chat based auction, storage providers connected to the Auctioneer can configure bidding to happen automatically as fast as their infrastructure can handle. 
 
-The SB collects all bids from connected storage providers and chooses one or multiple winners. The winning algorithm aims to maximize deal success rate for storage clients, while being fair to all storage providers, big or small, new or established. It is open and subject to continuous evolving based on community feedback. Anyone can join the biweekly [Auction Governance meeting](https://textile.notion.site/Auction-Governance-2eb1acae8a204b6e8dbf72752255a008) to contribute. As a rules of thumb, you can expect that the following facts will help winning an auction:
+The Auctioneer collects all bids from connected storage providers and chooses one or multiple winners. The winning algorithm aims to maximize deal success rate for storage clients, while being fair to all storage providers, big or small, new or established. It is open and subject to continuous evolving based on community feedback. Anyone can join the biweekly [Auction Governance meeting](https://textile.notion.site/Auction-Governance-2eb1acae8a204b6e8dbf72752255a008) to contribute. As a rules of thumb, you can expect that the following facts will help winning an auction:
 
-- Provide a low price per epoch. Verified deals need to be zero-priced for now.
-- Provide a low DealStartEpoch, and confirm the winning deal on chain as quick as possible.
+-- Provide a low price per epoch. Verified deals need to be zero-priced for now.
+-- Provide a low DealStartEpoch, and confirm the winning deal on chain as quick as possible.
 - Maintain a high deal success from past auctions.
 
-If you win an auction, you will be notified about it! If that weren't the case, you will see the declared winner published on the auction feed and most probably you'll have better luck in the next auction!
+If you win an auction, you will be notified about it! If that weren't the case, most probably you'll have better luck in the next auction!
 
-The SB relies on offline deals to make deals with storage providers. After you win an auction, you will pull the deal data from the SB's IPFS nodes. You can think of this flow as an *automatic* offline deal setup where instead of receiving hard drives, you'll pull the data from someplace and then receive the offline-deal proposal.
+The Auctioneer relies on offline deals to make deals with storage providers. After you win an auction, you will pull the deal data from the place given to your bidbot. You can think of this flow as an *automatic* offline deal setup where instead of receiving hard drives, you'll pull the data from someplace and then receive the offline-deal proposal.
 
 # How do I connect with the system?
 
-The hypothetical scenario in the previous section obviously didn't explain how you would really send bids or interact with the SB. The following diagram will help to get a better picture:
+The hypothetical scenario in the previous section obviously didn't explain how you would really send bids or interact with the Auctioneer. The following diagram will help to get a better picture:
 
-![https://user-images.githubusercontent.com/6136245/124800912-97025680-df2c-11eb-9052-350adbad0d51.png](https://user-images.githubusercontent.com/6136245/124800912-97025680-df2c-11eb-9052-350adbad0d51.png)
+![auctioneer + bidbots](https://user-images.githubusercontent.com/1369696/135887323-6b31cc1c-81e6-422e-9169-f09326680b69.png)
 
 To connect to the system, you will install `bidbot`, a daemon that you run on your infrastructure. 
 
-The `bidbot` talks to the SB through libp2p pubsub topics. This is the same technology used by many `libp2p` applications such as `lotus`. Through these topics, your `bidbot` daemon will receive new *auctions* and can send *bids* to participate.
+The `bidbot` talks to the Auctioneer through libp2p pubsub topics. This is the same technology used by many `libp2p` applications such as `lotus`. Through these topics, your `bidbot` daemon will receive new *auctions* and can send *bids* to participate.
 
-Whenever you win an auction, your `lotus-miner` will receive the deal proposal for the corresponding data so you can accept it, and a *ProposalCid* is generated. After acceptance, your `bidbot` will automatically download the *PayloadCid* data from the SB's IPFS nodes, and import it as you generally do with offline deals, simulating the following commands you might be aware of: `lotus-miner storage-deals import-data <dealCid> <carFilePath>`
+Whenever you win an auction, your `lotus-miner` will receive the deal proposal for the corresponding data so you can accept it, and a *ProposalCid* is generated. After acceptance, your `bidbot` will automatically download the *PayloadCid* data from the URL or IPFS multiaddrs given, and import it as you generally do with offline deals, simulating the following commands you might be aware of: `lotus-miner storage-deals import-data <dealCid> <carFilePath>`
 
-The `carFilePath` is the CAR file that `bidbot` generated after downloading the deals data from the SB. The *dealCid* is the *ProposalCid* of the proposal you previously accepted from the SB.
+The `carFilePath` is the CAR file that `bidbot` generated after downloading the deals data. The *dealCid* is the *ProposalCid* of the proposal you previously accepted from the Auctioneer.
 
 There's nothing more to do than the usual flow of deal execution steps from that moment forward. What's important is that the deal becomes active on-chain before the *StartDealEpoch* you promised in your bid!
 
@@ -95,7 +95,7 @@ Here're the steps to do it:
 3. The output will ask you to sign a token with the owner address of your miner.
 4. Configure your _ask price_, other bid settings, and auction filters. See `bidbot help daemon` for details. You can edit the configuration file generated by `bidbot init` (`~/.bidbot/config`) or use the equivalent flag for any given option.
 5. Use the signature you generated above to start the daemon as indicated by step 2. output.
-6. Good luck! Your `bidbot` will automatically bid in open deal auctions. If it wins an auction, the broker will automatically start making a deal with the Lotus miner address used in step 4.
+6. Good luck! Your `bidbot` will automatically bid in open deal auctions. If it wins an auction, the Auctioneer will automatically start making a deal with the Lotus miner address used in step 4.
 
 **Important configuration considerations for step 4:**
 - Bidbot will store the downloaded CAR files in `~/.bidbot/deal_data` by default. This directory should be accessible by your Lotus-miner for the CAR import step to work correctly. The default download folder would probably work if you run `bidbot` in the same host as your Lotus node. If you want to run `bidbot` and the Lotus node in separate hosts, you should set up a shared volume and set BIDBOT_DEAL_DATA_DIRECTORY environment variable on the `bidbot` host to change the download folder target. The shared volume should be mounted to the Lotus node host as the very same full path as the `bidbot` host.
@@ -109,9 +109,9 @@ Here're the steps to do it:
 
 # How does this fit in my current miner infrastructure?
 
-The following diagram shows how bidbot, SB, and your lotus-miner interact:
+The following diagram shows how bidbot, auctioneer, and your lotus-miner interact:
 
-![https://user-images.githubusercontent.com/6136245/124801028-bb5e3300-df2c-11eb-8547-af5d72e55993.png](https://user-images.githubusercontent.com/6136245/124801028-bb5e3300-df2c-11eb-8547-af5d72e55993.png)
+![auctioneer, bidbot, and lotus-miner](https://user-images.githubusercontent.com/1369696/135889226-19cf7830-8ed9-495f-a685-76e6f63c8b47.png)
 
 **Note**: you can install `bidbot` on the same host as your miner daemon, but there's a reasonable chance that you might want to avoid that for security reasons.
 
@@ -128,7 +128,7 @@ First, congratulation on being connected! When starting your `bidbot` daemon, yo
 2021-05-28T17:33:31.876-0300    INFO    bidbot/service  service/service.go:191  subscribed to the deal auction feed
 ```
 
-It's important to check that you see the last line ("subscribed to the deal auction feed") in your log output. This means you're connected to the SB successfully.
+It's important to check that you see the last line ("subscribed to the deal auction feed") in your log output. This means you're connected to the Auctioneer successfully.
 
 After some time, you'll see some activity in the log output, such as:
 
@@ -156,7 +156,7 @@ You'll also see bids that are proposed in the auction:
 {                                                                     
   "auction_id": "01f6tc0ygw6bpyj00e0k17secb",                                                                                                
   "storage_provider_id": "f02222",                                             
-  "wallet_addr_sig": "AbkFFEcauFXGH5Ob3gF4TTy9/e+kNX6midH2tl2SKtdgAFb5Qxy6+Gj38bUcRhQAy/bVjmoDC1oBvi1GbbjaGvgB",                                                                                                                                                                          
+  "wallet_addr_sig": "***",
   "ask_price": 10,                                                    
   "verified_ask_price": 10,                                           
   "start_epoch": 800506,                                              

--- a/main.go
+++ b/main.go
@@ -136,7 +136,8 @@ func init() {
 		{
 			Name:     "running-bytes-limit",
 			DefValue: "",
-			Description: `Maximum running total bytes in the deals to bid for a period of time.
+			Description: `Maximum running total bytes to process for a period of time.
+bidbot rejects new auctions if the limit would be exceeded.
 In the form of '10MiB/1m', '500 tb/24h' or '5 PiB / 128h', etc.
 See https://en.wikipedia.org/wiki/Byte#Multiple-byte_units for valid byte units.
 Default to no limit. Be aware that the bytes counter resets when bidbot restarts.


### PR DESCRIPTION
This PR:
1. mainly replace anything "broker" related. Given that we don't have an official name yet, I chose "auctioneer" because that's what bidbot interacts with, hence representing the view seen by storage providers. better names are welcome!
2. replace miners with storage providers for a few cases missed last time.
3. stop (incorrectly) mentioning IPFS nodes, URLs / IPFS multiaddrs instead.