### PR TITLE
cid-gravity: stop using deprecated rate limiting headers

### DIFF
--- a/service/pricing/cid_gravity.go
+++ b/service/pricing/cid_gravity.go
@@ -144,7 +144,7 @@ func (cg *clientRules) maybeReloadRules(url string, timeout time.Duration, cache
 	}
 	if t := cg.apiThrottlingReset.Load(); t != nil {
 		reset := t.(time.Time)
-		if !reset.IsZero() && time.Now().Before(reset) {
+		if time.Now().Before(reset) {
 			log.Infof("API rate limit won't reset until: %v", reset)
 			return false
 		}
@@ -187,7 +187,6 @@ func (cg *clientRules) loadRules(url string) error {
 		return fmt.Errorf("contacting CID gravity server: %v", err)
 	}
 
-	cg.apiThrottlingReset.Store(time.Time{})
 	switch resp.StatusCode {
 	case http.StatusOK:
 		// proceed

--- a/service/pricing/cid_gravity_test.go
+++ b/service/pricing/cid_gravity_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 	"time"
 
@@ -204,11 +203,9 @@ func TestMaybeReloadRules(t *testing.T) {
 	})
 	t.Run("API rate limit", func(t *testing.T) {
 		reqs := 0
+		backoff429 = time.Millisecond * 100
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if reqs == 0 {
-				rw.Header().Set("X-Ratelimit-Limit", "1")
-				rw.Header().Set("X-Ratelimit-Remaining", "0")
-				rw.Header().Set("X-Ratelimit-Reset", strconv.FormatInt(time.Now().Add(time.Second).Unix(), 10))
 				rw.WriteHeader(http.StatusTooManyRequests)
 			} else {
 				response, _ := json.Marshal(rawRules{MaintenanceMode: true})


### PR DESCRIPTION
The `X-Ratelimit-***` headers will be retired from the cid-gravity API.
As we talked with Julien, the current strategy will be simply to have a fixed backoff instead of relying on the backend to provide that deadline.