### PR TITLE
gc: take care of symlinks appropriately 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,11 @@ go 1.16
 
 require (
 	github.com/dustin/go-humanize v1.0.0
+	github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c // indirect
+	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
+	github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 // indirect
+	github.com/facebookgo/symwalk v0.0.0-20150726040526-42004b9f3222
+	github.com/facebookgo/testname v0.0.0-20150612200628-5443337c3a12 // indirect
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-amt-ipld/v2 v2.1.1-0.20201006184820-924ee87a1349 // indirect
 	github.com/filecoin-project/go-jsonrpc v0.1.4-0.20210217175800-45ea43ac2bec

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,16 @@ github.com/etclabscore/go-jsonschema-walk v0.0.6/go.mod h1:VdfDY72AFAiUhy0ZXEaWS
 github.com/etclabscore/go-openrpc-reflect v0.0.36/go.mod h1:0404Ky3igAasAOpyj1eESjstTyneBAIk5PgJFbK4s5E=
 github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5 h1:BBso6MBKW8ncyZLv37o+KNyy0HrrHgfnOaGQC2qvN+A=
 github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5/go.mod h1:JpoxHjuQauoxiFMl1ie8Xc/7TfLuMZ5eOCONd1sUBHg=
+github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c h1:8ISkoahWXwZR41ois5lSJBSVw4D0OV19Ht/JSTzvSv0=
+github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c/go.mod h1:Yg+htXGokKKdzcwhuNDwVvN+uBxDGXJ7G/VN1d8fa64=
+github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=
+github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
+github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpmbhCOZJ293Lz68O7PYrF2EzeiFMwCLk=
+github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
+github.com/facebookgo/symwalk v0.0.0-20150726040526-42004b9f3222 h1:ivxAxcE9py2xLAqpcEwN7sN711aLfEWgh3cY0aha7uY=
+github.com/facebookgo/symwalk v0.0.0-20150726040526-42004b9f3222/go.mod h1:PgrCjL2+FgkITqxQI+erRTONtAv4JkpOzun5ozKW/Jg=
+github.com/facebookgo/testname v0.0.0-20150612200628-5443337c3a12 h1:pKeuUgeuL6jk/FpxSr0ZVL1XEiOmrcWBvB2rKXu0mMI=
+github.com/facebookgo/testname v0.0.0-20150612200628-5443337c3a12/go.mod h1:IYed2VYeQcs7JTN6KiVXjaz6Rv/Qz092Wjc6o5bCJ9I=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.8.0/go.mod h1:3l45GVGkyrnYNl9HoIjnp2NnNWvh6hLAqD8yTfGjnw8=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/facebookgo/symwalk"
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
 	dsq "github.com/ipfs/go-datastore/query"
@@ -32,7 +33,7 @@ import (
 
 const (
 	// gcInterval specifies how often to run the periodical garbage collector.
-	gcInterval = time.Minute // TODO(jsign): remove temporal change while is a PR
+	gcInterval = time.Second * 30 // TODO(jsign): remove temporal change while is a PR
 	// defaultListLimit is the default list page size.
 	defaultListLimit = 10
 	// maxListLimit is the max list page size.
@@ -741,7 +742,7 @@ func (s *Store) GC(discardOrphanDealsAfter time.Duration) (bidsRemoved, filesRem
 		}
 		return nil
 	}
-	err = filepath.Walk(s.dealDataDirectory, walk)
+	err = symwalk.Walk(s.dealDataDirectory, walk)
 	if err != nil {
 		log.Errorf("error walking deal data directory: %v", err)
 	}

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -720,7 +720,7 @@ func (s *Store) GC(discardOrphanDealsAfter time.Duration) (bidsRemoved, filesRem
 			return nil
 		}
 		if info.IsDir() {
-			log.Infof("gc ignoring symlink file %s", path)
+			log.Infof("gc ignoring directory %s", path)
 			return nil
 		}
 		filesEvaluated++

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// gcInterval specifies how often to run the periodical garbage collector.
-	gcInterval = time.Hour
+	gcInterval = time.Minute // TODO(jsign): remove temporal change while is a PR
 	// defaultListLimit is the default list page size.
 	defaultListLimit = 10
 	// maxListLimit is the max list page size.
@@ -714,7 +714,12 @@ func (s *Store) GC(discardOrphanDealsAfter time.Duration) (bidsRemoved, filesRem
 			log.Errorf("error walking into %s: %v", path, err)
 			return nil
 		}
+		if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+			log.Infof("gc ignoring symlink %s", path)
+			return nil
+		}
 		if info.IsDir() {
+			log.Infof("gc ignoring symlink file %s", path)
 			return nil
 		}
 		shouldRemove := false

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -674,15 +674,15 @@ func (s *Store) periodicalGC(discardOrphanDealsAfter time.Duration) {
 			return
 		}
 		start := time.Now()
-		bidsRemoved, filesRemoved := s.GC(discardOrphanDealsAfter)
-		log.Infof("GC finished in %v: %d orphan deals cleaned, %d deal data files cleaned",
-			time.Since(start), bidsRemoved, filesRemoved)
+		bidsRemoved, filesRemoved, evaluated := s.GC(discardOrphanDealsAfter)
+		log.Infof("GC finished in %v: %d orphan deals cleaned, %d deal data files cleaned, %d files evaluated",
+			time.Since(start), bidsRemoved, filesRemoved, evaluated)
 	}
 }
 
 // GC cleans up deal data files, if discardOrphanDealsAfter is not zero, it
 // also removes bids staying at BidStatusAwaitingProposal for that longer.
-func (s *Store) GC(discardOrphanDealsAfter time.Duration) (bidsRemoved, filesRemoved int) {
+func (s *Store) GC(discardOrphanDealsAfter time.Duration) (bidsRemoved, filesRemoved, filesEvaluated int) {
 	bids, err := s.ListBids(Query{})
 	if err != nil {
 		log.Errorf("listing bids: %v", err)
@@ -722,6 +722,7 @@ func (s *Store) GC(discardOrphanDealsAfter time.Duration) (bidsRemoved, filesRem
 			log.Infof("gc ignoring symlink file %s", path)
 			return nil
 		}
+		filesEvaluated++
 		shouldRemove := false
 		if _, exists := removeFiles[path]; exists {
 			shouldRemove = true

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// gcInterval specifies how often to run the periodical garbage collector.
-	gcInterval = time.Second * 30 // TODO(jsign): remove temporal change while is a PR
+	gcInterval = time.Hour
 	// defaultListLimit is the default list page size.
 	defaultListLimit = 10
 	// maxListLimit is the max list page size.


### PR DESCRIPTION
Symlinks not being handled correctly was creating an unfortunate situation:
1. The rule to ignore "directory" inodes in the filepath walk was not detecting that `deal_data` was a symlink, so it was removing the symlink all over. This means that for storage providers that were using symlinks, the symlink would magically disappear
2. `filepath.Walk` doesn't follow symlinks. So if `deal_data` is a symlink to another folder, walking the folder results in 0 files, thus directly _no GC was being done_.

This fix is only relevant for storage providers that have symlink in `deal_data`.

Closes https://github.com/textileio/bidbot/issues/69
Closes https://github.com/textileio/bidbot/issues/70