### PR TITLE
store: allow boosted downloads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/libp2p/go-libp2p-connmgr v0.2.4
 	github.com/libp2p/go-libp2p-core v0.9.0
+	github.com/melbahja/got v0.6.1
 	github.com/multiformats/go-multiaddr v0.4.1
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multibase v0.0.3
@@ -45,7 +46,6 @@ require (
 	github.com/textileio/go-ds-badger3 v0.0.0-20210324034212-7b7fb3be3d1c
 	github.com/textileio/go-libp2p-pubsub-rpc v0.0.6
 	github.com/textileio/go-log/v2 v2.1.3-gke-2
-	github.com/urfave/cli/v2 v2.3.0 // indirect
 	go.opentelemetry.io/otel/metric v0.21.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -1349,6 +1349,8 @@ github.com/mdlayher/netlink v0.0.0-20190828143259-340058475d09/go.mod h1:KxeJAFO
 github.com/mdlayher/netlink v1.0.0/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
 github.com/mdlayher/netlink v1.1.0/go.mod h1:H4WCitaheIsdF9yOYu8CFmCgQthAPIWZmcKp9uZHgmY=
 github.com/mdlayher/wifi v0.0.0-20190303161829-b1436901ddee/go.mod h1:Evt/EIne46u9PtQbeTx2NTcqURpr5K4SvKtGmBuDPN8=
+github.com/melbahja/got v0.6.1 h1:K3nB60YVNWFsZDRXrY3VZ7/pUfVjPBZ3VTJwf9hGYFY=
+github.com/melbahja/got v0.6.1/go.mod h1:3NbG1yxji7B3aU1cyGNgzTdCDDI2AkF16Pn/bg7okng=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -1842,6 +1844,9 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zondax/hid v0.9.0/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 github.com/zondax/ledger-go v0.12.1/go.mod h1:KatxXrVDzgWwbssUWsF5+cOJHXPvzQ09YSlzGNuhOEo=
+gitlab.com/poldi1405/go-ansi v1.1.0/go.mod h1:TLoRttGdPaq5H2qfF7I1cC5Lt2WXtQeIkFurjbUf6OI=
+gitlab.com/poldi1405/go-indicators v0.0.0-20200820134929-9b373aa411a5/go.mod h1:jn34qwBiXTHz73wD9neAMeJGCeMijVro+WCqk1RJXL4=
+gitlab.com/poldi1405/go-indicators v1.0.0/go.mod h1:jn34qwBiXTHz73wD9neAMeJGCeMijVro+WCqk1RJXL4=
 go.dedis.ch/fixbuf v1.0.3/go.mod h1:yzJMt34Wa5xD37V5RTdmp38cz3QhMagdGoem9anUalw=
 go.dedis.ch/kyber/v3 v3.0.4/go.mod h1:OzvaEnPvKlyrWyp3kGXlFdp7ap1VC6RkZDTaPikqhsQ=
 go.dedis.ch/kyber/v3 v3.0.9/go.mod h1:rhNjUUg6ahf8HEg5HUvVBYoWY4boAafX8tYxX+PS+qg=

--- a/main.go
+++ b/main.go
@@ -155,9 +155,10 @@ No limit by default.`,
 			Description: `If bigger than zero, only run that many imports concurrently. Zero means no limits.`,
 		},
 		{
-			Name:        "boost-download",
-			DefValue:    false,
-			Description: `Experimental: creates multiple TCP connections to boost download speeds. Use with caution since might not be compatible in all filesystems.`,
+			Name:     "boost-download",
+			DefValue: false,
+			Description: `Experimental: creates multiple TCP connections to boost download speeds. 
+Use with caution since might not be compatible in all filesystems.`,
 		},
 		{
 			Name:     "sealing-sectors-limit",

--- a/main.go
+++ b/main.go
@@ -154,7 +154,11 @@ No limit by default.`,
 			DefValue:    0,
 			Description: `If bigger than zero, only run that many imports concurrently. Zero means no limits.`,
 		},
-
+		{
+			Name:        "boost-download",
+			DefValue:    false,
+			Description: `Experimental: creates multiple TCP connections to boost download speeds. Use with caution since might not be compatible in all filesystems.`,
+		},
 		{
 			Name:     "sealing-sectors-limit",
 			DefValue: 0,
@@ -405,6 +409,7 @@ var daemonCmd = &cobra.Command{
 			},
 			BytesLimiter:        bytesLimiter,
 			ConcurrentImports:   v.GetInt("concurrent-imports-limit"),
+			BoostDownload:       v.GetBool("boost-download"),
 			SealingSectorsLimit: v.GetInt("sealing-sectors-limit"),
 			PricingRules:        pricing.EmptyRules{},
 			PricingRulesStrict:  v.GetBool("cid-gravity-strict"),

--- a/service/service.go
+++ b/service/service.go
@@ -59,6 +59,7 @@ type Config struct {
 	AuctionFilters      AuctionFilters
 	BytesLimiter        limiter.Limiter
 	ConcurrentImports   int
+	BoostDownload       bool
 	SealingSectorsLimit int
 	PricingRules        pricing.PricingRules
 	PricingRulesStrict  bool
@@ -202,6 +203,7 @@ func New(
 		conf.BidParams.DiscardOrphanDealsAfter,
 		conf.BytesLimiter,
 		conf.ConcurrentImports,
+		conf.BoostDownload,
 	)
 	if err != nil {
 		return nil, fin.Cleanupf("creating bid store: %v", err)

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -510,10 +510,6 @@ func (s *Store) WriteDealData(b *Bid) (string, error) {
 
 // WriteDataURI writes the uri resource to the configured deal data directory.
 func (s *Store) WriteDataURI(bidID auction.BidID, payloadCid, uri string, size uint64) (string, error) {
-	duri, err := datauri.NewURI(payloadCid, uri)
-	if err != nil {
-		return "", fmt.Errorf("parsing data uri: %w", err)
-	}
 	carDownloadPath := s.dealDataFilePathFor(bidID, payloadCid)
 
 	if s.boostedDownload {
@@ -539,6 +535,11 @@ func (s *Store) WriteDataURI(bidID auction.BidID, payloadCid, uri string, size u
 		return "", fmt.Errorf("seeking file to the beginning: %v", err)
 	}
 	log.Debugf("fetching %s with timeout of %v", uri, s.dealDataFetchTimeout)
+
+	duri, err := datauri.NewURI(payloadCid, uri)
+	if err != nil {
+		return "", fmt.Errorf("parsing data uri: %w", err)
+	}
 	if err := duri.Write(ctx, f); err != nil {
 		return "", fmt.Errorf("writing data uri %s: %w", uri, err)
 	}

--- a/service/store/store_test.go
+++ b/service/store/store_test.go
@@ -268,7 +268,7 @@ func newStore(t *testing.T) (*Store, format.DAGService, blockstore.Blockstore) {
 	})
 	require.NoError(t, err)
 	s, err := NewStore(ds, newFilClientMock(), newLotusClientMock(), t.TempDir(), 2, time.Second, nil, 0,
-		limiter.NopeLimiter{}, 1<<30)
+		limiter.NopeLimiter{}, 1<<30, false)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, s.Close())


### PR DESCRIPTION
Includes an experimental flag `--boost-download` which opens multiple TCP connections in content-range compatible HTTP endpoints. If the endpoint isn't compatible, it will fall back to doing usual downloads.

Leaving this as a PR until I've some feedback from a storage provider doing some tests and confirming.