### PR TITLE
Accept signature from storage provider Worker address

### DIFF
--- a/lib/filclient/filclient.go
+++ b/lib/filclient/filclient.go
@@ -88,6 +88,11 @@ func (fc *LotusFilClient) VerifyBidder(
 	}
 
 	okOwner, errVerifySigOwner := fc.verifySignature(mi.Owner, sig, bidderID)
+	// Do an early return to avoid double work.
+	if errVerifySigOwner == nil && okOwner {
+		return true, nil
+	}
+
 	okWorker, errVerifySigWorker := fc.verifySignature(mi.Worker, sig, bidderID)
 	if errVerifySigOwner != nil && errVerifySigWorker != nil {
 		return false, fmt.Errorf(
@@ -95,7 +100,7 @@ func (fc *LotusFilClient) VerifyBidder(
 			errVerifySigOwner, errVerifySigWorker)
 	}
 
-	return okOwner || okWorker, nil
+	return okWorker, nil
 }
 
 func (fc *LotusFilClient) verifySignature(

--- a/lib/filclient/filclient.go
+++ b/lib/filclient/filclient.go
@@ -63,7 +63,10 @@ func (fc *LotusFilClient) Close() error {
 
 // VerifyBidder ensures that the wallet address authorized the use of bidder peer.ID to make bids.
 // Miner's authorize a bidding peer.ID by signing it with a wallet address private key.
-func (fc *LotusFilClient) VerifyBidder(bidderSig []byte, bidderID peer.ID, storageProviderIDStr string) (bool, error) {
+func (fc *LotusFilClient) VerifyBidder(
+	bidderSig []byte,
+	bidderID peer.ID,
+	storageProviderIDStr string) (bool, error) {
 	if fc.fakeMode {
 		return true, nil
 	}
@@ -87,13 +90,18 @@ func (fc *LotusFilClient) VerifyBidder(bidderSig []byte, bidderID peer.ID, stora
 	okOwner, errVerifySigOwner := fc.verifySignature(mi.Owner, sig, bidderID)
 	okWorker, errVerifySigWorker := fc.verifySignature(mi.Worker, sig, bidderID)
 	if errVerifySigOwner != nil && errVerifySigWorker != nil {
-		return false, fmt.Errorf("verifying signature from owner (err: %s) or worker (err: %s) failed", errVerifySigOwner, errVerifySigWorker)
+		return false, fmt.Errorf(
+			"verifying signature from owner (err: %s) or worker (err: %s) failed",
+			errVerifySigOwner, errVerifySigWorker)
 	}
 
 	return okOwner || okWorker, nil
 }
 
-func (fc *LotusFilClient) verifySignature(target address.Address, sig crypto.Signature, bidderID peer.ID) (bool, error) {
+func (fc *LotusFilClient) verifySignature(
+	target address.Address,
+	sig crypto.Signature,
+	bidderID peer.ID) (bool, error) {
 	ctx, cancel := context.WithTimeout(fc.ctx, requestTimeout)
 	defer cancel()
 	targetWalletAddr, err := fc.fullNode.StateAccountKey(ctx, target, types.EmptyTSK)

--- a/lib/filclient/filclient.go
+++ b/lib/filclient/filclient.go
@@ -94,13 +94,17 @@ func (fc *LotusFilClient) VerifyBidder(
 	}
 
 	okWorker, errVerifySigWorker := fc.verifySignature(mi.Worker, sig, bidderID)
+	if errVerifySigWorker == nil && okWorker {
+		return true, nil
+	}
+
 	if errVerifySigOwner != nil && errVerifySigWorker != nil {
 		return false, fmt.Errorf(
 			"verifying signature from owner (err: %s) or worker (err: %s) failed",
 			errVerifySigOwner, errVerifySigWorker)
 	}
 
-	return okWorker, nil
+	return false, nil
 }
 
 func (fc *LotusFilClient) verifySignature(

--- a/main.go
+++ b/main.go
@@ -278,9 +278,9 @@ The change the deal data directory, set the $BIDBOT_DEAL_DATA_DIRECTORY environm
 
 		fmt.Printf(`Bidbot needs a signature from a miner wallet address to authenticate bids.
 
-1. Sign this token with an address from your miner owner Lotus wallet address:
+1. Sign this token with an address from your miner owner or worker Lotus wallet address of the storage provider:
 
-    lotus wallet sign [owner-address] %s
+    lotus wallet sign [owner-or-worker-address] %s
 
 2. Start listening for deal auctions using the wallet address and signature from step 1:
 


### PR DESCRIPTION
This PR adds support for validating the storage provide signature using its Worker address.
To avoid breaking compatibility, it considers a signature being valid if is a valid signature from the Owner **or** Worker addresses.