### PR TITLE
Use faster API call to avoid tight bid proposals

### DIFF
--- a/service/lotusclient/lotusclient.go
+++ b/service/lotusclient/lotusclient.go
@@ -110,8 +110,8 @@ func (c *Client) HealthCheck() error {
 	ctx, cancel := context.WithTimeout(c.ctx, requestTimeout)
 	defer cancel()
 	start := time.Now()
-	_, err := c.cmkt.MarketListIncompleteDeals(ctx)
-	log.Infof("MarketListIncompleteDeals call took %v", time.Since(start))
+	_, err := c.cmkt.MarketGetAsk(ctx)
+	log.Infof("MarketGetAsk call took %v (err: %v)", time.Since(start), err)
 	return err
 }
 


### PR DESCRIPTION
After a hairy situation with a particular storage provider, I've realized that in some Lotus node which high load the current API we used for health checking bidbot before bidding can take too much time (>30s in his case).

This is very bad since the auction usual duration is 30s, which means that by the time the health check finishes and bidbot decide to bid, it's too late for that bid to be processed.

We switch here to an API call that should be independent on deal load/in-progress from the node, so safer to use as a health check.