### PR TITLE
mod: upgrade go-libp2p-pubsub-rpc with QUIC libp2p fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,9 @@ name: Release
 on:
   push:
     branches:
-      - '**'
+      - '_**'
     tags:
-      - 'v*'
+      - '_v*'
 
 jobs:
   release:

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/textileio/crypto v0.0.0-20210929130053-08edebc3361a
 	github.com/textileio/go-datastore-extensions v1.0.1
 	github.com/textileio/go-ds-badger3 v0.1.0
-	github.com/textileio/go-libp2p-pubsub-rpc v0.0.8
+	github.com/textileio/go-libp2p-pubsub-rpc v0.0.9
 	github.com/textileio/go-log/v2 v2.1.3-gke-2
 	go.opentelemetry.io/otel/metric v0.25.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -1837,6 +1837,8 @@ github.com/textileio/go-ds-badger3 v0.1.0 h1:q0kBuBmAcRUR3ClMSYlyw0224XeuzjjGinU
 github.com/textileio/go-ds-badger3 v0.1.0/go.mod h1:z8LuXcihtZ91spEaqhEiNGIWx3E59iFq1HZj4gwwGrU=
 github.com/textileio/go-libp2p-pubsub-rpc v0.0.8 h1:vkp/unXCvYbra7GUiHZVpxg7g69iSo1XUmcdhCVXkk4=
 github.com/textileio/go-libp2p-pubsub-rpc v0.0.8/go.mod h1:3rOV6TxePSwADKpnwXBKpTjAA4QyjZBus13xc6VCtSw=
+github.com/textileio/go-libp2p-pubsub-rpc v0.0.9 h1:yA58Giu0WYxS5+ixDTKDktMKcwWhqjDESEHf5aykZgE=
+github.com/textileio/go-libp2p-pubsub-rpc v0.0.9/go.mod h1:3rOV6TxePSwADKpnwXBKpTjAA4QyjZBus13xc6VCtSw=
 github.com/textileio/go-log/v2 v2.1.3-gke-1/go.mod h1:DwACkjFS3kjZZR/4Spx3aPfSsciyslwUe5bxV8CEU2w=
 github.com/textileio/go-log/v2 v2.1.3-gke-2 h1:YkMA5ua0Cf/X6CkbexInsoJ/HdaHQBlgiv9Yy9hddNM=
 github.com/textileio/go-log/v2 v2.1.3-gke-2/go.mod h1:DwACkjFS3kjZZR/4Spx3aPfSsciyslwUe5bxV8CEU2w=


### PR DESCRIPTION
This PR upgrades to a newer version of `go-libp2p-pubsub-rpc`, which contains a fix for the case that the libp2p host has QUIC enabled. This fix was simply a side-effect of the libp2p update already enabling QUIC by default, so it can't be sent explicitly as an extra protocol to support (because it's already included in defaults).

Closes https://github.com/textileio/bidbot/issues/96