### PR TITLE
cidgravity: adjust to new api change

### DIFF
--- a/service/pricing/cid_gravity.go
+++ b/service/pricing/cid_gravity.go
@@ -33,7 +33,7 @@ type rawRules struct {
 	DealRateLimit   int
 	CurrentDealRate int
 	PricingRules    []struct {
-		Verified    bool
+		Verified    string
 		MinSize     uint64 // bytes
 		MaxSize     uint64 // bytes
 		MinDuration uint64 // epoches
@@ -119,9 +119,9 @@ func (cg *clientRules) PricesFor(auction *pb.Auction) (prices ResolvedPrices, va
 	for _, r := range rules.PricingRules {
 		if auction.DealSize >= r.MinSize && auction.DealSize <= r.MaxSize &&
 			auction.DealDuration >= r.MinDuration && auction.DealDuration <= r.MaxDuration {
-			if r.Verified && !prices.VerifiedPriceValid {
+			if (r.Verified == "true" || r.Verified == "any") && !prices.VerifiedPriceValid {
 				prices.VerifiedPriceValid, prices.VerifiedPrice = true, r.Price
-			} else if !prices.UnverifiedPriceValid {
+			} else if (r.Verified == "false" || r.Verified == "any") && !prices.UnverifiedPriceValid {
 				prices.UnverifiedPriceValid, prices.UnverifiedPrice = true, r.Price
 			}
 			if prices.VerifiedPriceValid && prices.UnverifiedPriceValid {

--- a/service/pricing/cid_gravity_test.go
+++ b/service/pricing/cid_gravity_test.go
@@ -17,7 +17,7 @@ func TestPriceFor(t *testing.T) {
 	cidGravityCachePeriod = time.Second
 	rules := &rawRules{
 		PricingRules: []struct {
-			Verified    bool
+			Verified    string
 			MinSize     uint64
 			MaxSize     uint64
 			MinDuration uint64
@@ -25,32 +25,32 @@ func TestPriceFor(t *testing.T) {
 			Price       int64
 		}{
 			{
-				Verified: false, Price: 100,
+				Verified: "false", Price: 100,
 				MinSize: 2 << 20, MaxSize: 2<<30 - 1,
 				MinDuration: 1, MaxDuration: 2 << 10,
 			},
 			{
-				Verified: false, Price: 10,
+				Verified: "false", Price: 10,
 				MinSize: 2 << 30, MaxSize: 2<<40 - 1,
 				MinDuration: 1, MaxDuration: 2 << 10,
 			},
 			{
-				Verified: false, Price: 1000,
+				Verified: "false", Price: 1000,
 				MinSize: 2 << 30, MaxSize: 2<<40 - 1,
 				MinDuration: 2 >> 10, MaxDuration: 2 << 30,
 			},
 			{
-				Verified: true, Price: 1,
+				Verified: "true", Price: 1,
 				MinSize: 1, MaxSize: 2<<30 - 1,
 				MinDuration: 1, MaxDuration: 2 << 10,
 			},
 			{
-				Verified: true, Price: 0,
+				Verified: "true", Price: 0,
 				MinSize: 2 << 30, MaxSize: 2<<40 - 1,
 				MinDuration: 1, MaxDuration: 2 << 10,
 			},
 			{
-				Verified: true, Price: 100,
+				Verified: "true", Price: 100,
 				MinSize: 2 << 30, MaxSize: 2<<40 - 1,
 				MinDuration: 2 >> 10, MaxDuration: 2 << 30,
 			},
@@ -137,7 +137,7 @@ func TestMaybeReloadRules(t *testing.T) {
 	apiResponse := []byte(`{
 	     "pricingRules": [
 		     {
-		          "verified": false,
+		          "verified": "false",
 		          "minSize": 1,
 		          "maxSize": 2,
 		          "minDuration": 1,


### PR DESCRIPTION
Cid Gravity changed the `Verified` field in the rules from `bool` to `string`.
The new allowed values are `"true"`, `"false"`, and `"any"`. The first two have the same semantics of the previous boolean type. The latter means that the rule applies both for verified and unverified deals.

Closes #103