### PR TITLE
Add Concurrent Data Download Limit Flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,6 +155,11 @@ No limit by default.`,
 			Description: `If bigger than zero, only run that many imports concurrently. Zero means no limits.`,
 		},
 		{
+			Name:        "concurrent-data-download-limit",
+			DefValue:    store.MaxDataURIFetchConcurrency,
+			Description: `The maximum number of concurrent data fetches; default is 3`,
+		},
+		{
 			Name:     "boost-download",
 			DefValue: false,
 			Description: `Experimental: creates multiple TCP connections to boost download speeds. 
@@ -420,6 +425,7 @@ var daemonCmd = &cobra.Command{
 			SealingSectorsLimit: v.GetInt("sealing-sectors-limit"),
 			PricingRules:        pricing.EmptyRules{},
 			PricingRulesStrict:  v.GetBool("cid-gravity-strict"),
+			ConcurrentDownloads: v.GetInt("concurrent-data-download-limit"),
 		}
 		if cidGravityKey := v.GetString("cid-gravity-key"); cidGravityKey != "" {
 			config.PricingRules = pricing.NewCIDGravityRules(cidGravityURL, cidGravityKey)

--- a/main.go
+++ b/main.go
@@ -157,7 +157,7 @@ No limit by default.`,
 		{
 			Name:        "concurrent-data-download-limit",
 			DefValue:    store.MaxDataURIFetchConcurrency,
-			Description: `The maximum number of concurrent data fetches; default is 3`,
+			Description: `The maximum number of concurrent data fetches`,
 		},
 		{
 			Name:     "boost-download",

--- a/service/service.go
+++ b/service/service.go
@@ -64,6 +64,7 @@ type Config struct {
 	SealingSectorsLimit int
 	PricingRules        pricing.PricingRules
 	PricingRulesStrict  bool
+	ConcurrentDownloads int
 }
 
 // BidParams defines how bids are made.
@@ -205,6 +206,7 @@ func New(
 		conf.BytesLimiter,
 		conf.ConcurrentImports,
 		conf.ChunkedDownload,
+		conf.ConcurrentDownloads,
 	)
 	if err != nil {
 		return nil, fin.Cleanupf("creating bid store: %v", err)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -269,9 +269,10 @@ func validConfig(t *testing.T) (service.Config, txndswrap.TxnDatastore) {
 	}
 	peerConfig, dir := newPeerConfig(t)
 	config := service.Config{
-		AuctionFilters: auctionFilters,
-		BidParams:      bidParams,
-		Peer:           peerConfig,
+		AuctionFilters:      auctionFilters,
+		BidParams:           bidParams,
+		Peer:                peerConfig,
+		ConcurrentDownloads: 3,
 	}
 
 	store, err := dshelper.NewBadgerTxnDatastore(filepath.Join(dir, "bidstore"))

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -181,6 +181,7 @@ func NewStore(
 	bytesLimiter limiter.Limiter,
 	concurrentImports int,
 	chunkedDownload bool,
+	concurrentDownloads int,
 ) (*Store, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Store{
@@ -189,8 +190,8 @@ func NewStore(
 		lc:           lc,
 		bytesLimiter: bytesLimiter,
 
-		jobCh:  make(chan *Bid, MaxDataURIFetchConcurrency),
-		tickCh: make(chan struct{}, MaxDataURIFetchConcurrency),
+		jobCh:  make(chan *Bid, concurrentDownloads),
+		tickCh: make(chan struct{}, concurrentDownloads),
 
 		dealDataDirectory:     dealDataDirectory,
 		dealDataFetchAttempts: dealDataFetchAttempts,
@@ -212,8 +213,8 @@ func NewStore(
 		return nil, fmt.Errorf("fails health check: %w", err)
 	}
 	// Create data fetch workers
-	s.wg.Add(MaxDataURIFetchConcurrency)
-	for i := 0; i < MaxDataURIFetchConcurrency; i++ {
+	s.wg.Add(concurrentDownloads)
+	for i := 0; i < concurrentDownloads; i++ {
 		go s.fetchWorker(i + 1)
 	}
 

--- a/service/store/store_test.go
+++ b/service/store/store_test.go
@@ -284,7 +284,8 @@ func newStore(t *testing.T) (*Store, format.DAGService, blockstore.Blockstore) {
 		0,
 		limiter.NopeLimiter{},
 		1<<30,
-		false)
+		false,
+		3)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, s.Close())


### PR DESCRIPTION
## What Changed
Add a new flag `concurrent-data-download-limit` to the bidbot daemon.

## Why
Enables storage providers to increase the number of parallel data downloads instead of the hardcoded limit of 3.

## Testing
- Ran bidbot in production with `concurrent-data-download-limit` set to 10 and saw an increase in data throughput.
- `go test ./...` passed

![Screen Shot 2022-06-10 at 12 20 06 PM](https://user-images.githubusercontent.com/80299009/173136082-5a74b55f-e601-43c1-9e97-f8e8a7c3b23c.png)
